### PR TITLE
remove social media from contact options

### DIFF
--- a/templates/lib/layout.html
+++ b/templates/lib/layout.html
@@ -42,10 +42,7 @@
                 · <a href="{{url_for('privacy')}}">Privacy</a>
             </p>
             <p>Report issues <a href='https://github.com/codl/forget/issues'>on Github</a>
-               or directly to codl on
-                    <a href="https://twitter.com/codl">Twitter</a>,
-                    <a href="https://chitter.xyz/@codl">Mastodon</a>,
-                    or by <a href="mailto:codl@codl.fr">Email</a>.
+               or <a href="mailto:codl@codl.fr">via Email</a>.
                </p>
         </footer>
     </body>


### PR DESCRIPTION
i dont check twitter anymore and i dont really want to do tech support over social media anyway