### PR TITLE
remove x- prefix from headers

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+## v1.4.2
+
+* internals: removed `x-` prefix from custom headers, as per [section 8.3.1 of RFC7231](https://httpwg.org/specs/rfc7231.html#considerations.for.new.header.fields)
+
 ## v1.4.1 (security update)
 
 Released 2018-10-29

--- a/libforget/brotli.py
+++ b/libforget/brotli.py
@@ -35,9 +35,9 @@ class BrotliCache(object):
         cache_key = 'brotlicache:{}'.format(digest)
 
         encbody = self.redis.get(cache_key)
-        response.headers.set('x-brotli-cache', 'HIT')
+        response.headers.set('brotli-cache', 'HIT')
         if not encbody:
-            response.headers.set('x-brotli-cache', 'MISS')
+            response.headers.set('brotli-cache', 'MISS')
             lock_key = 'brotlicache:lock:{}'.format(digest)
             if self.redis.set(lock_key, 1, nx=True, ex=10):
                 mode = (
@@ -52,9 +52,9 @@ class BrotliCache(object):
                     t.join(self.timeout)
                     encbody = self.redis.get(cache_key)
                 if not encbody:
-                    response.headers.set('x-brotli-cache', 'TIMEOUT')
+                    response.headers.set('brotli-cache', 'TIMEOUT')
             else:
-                response.headers.set('x-brotli-cache', 'LOCKED')
+                response.headers.set('brotli-cache', 'LOCKED')
         if encbody:
             response.headers.set('content-encoding', 'br')
             response.headers.set('vary', 'accept-encoding')

--- a/libforget/img_proxy.py
+++ b/libforget/img_proxy.py
@@ -118,7 +118,7 @@ class ImgProxyCache(object):
             return abort(404)
 
         resp = make_response(body, 200)
-        resp.headers.set('x-imgproxy-cache', x_imgproxy_cache)
+        resp.headers.set('imgproxy-cache', x_imgproxy_cache)
         resp.headers.set('cache-control', 'max-age={}'.format(self.expire))
         for key, value in headers.items():
             resp.headers.set(key, value)

--- a/test/test_libbrotli.py
+++ b/test/test_libbrotli.py
@@ -65,7 +65,7 @@ def test_brotli_dynamic(br_client):
             '/',
             headers=[('accept-encoding', 'gzip, br')])
 
-    assert resp.headers.get('x-brotli-cache') == 'MISS'
+    assert resp.headers.get('brotli-cache') == 'MISS'
     assert resp.headers.get('content-encoding') == 'br'
     assert b"Hello, world!" in decompress(resp.data)
 
@@ -84,7 +84,7 @@ def test_brotli_dynamic_cache(br_client):
             '/',
             headers=[('accept-encoding', 'gzip, br')])
 
-    assert resp.headers.get('x-brotli-cache') == 'HIT'
+    assert resp.headers.get('brotli-cache') == 'HIT'
     assert resp.headers.get('content-encoding') == 'br'
     assert b"Hello, world!" in decompress(resp.data)
 
@@ -104,7 +104,7 @@ def test_brotli_dynamic_timeout(app):
             '/hard_to_compress',
             headers=[('accept-encoding', 'gzip, br')])
 
-    assert resp.headers.get('x-brotli-cache') == 'TIMEOUT'
+    assert resp.headers.get('brotli-cache') == 'TIMEOUT'
     assert resp.headers.get('content-encoding') != 'br'
 
 
@@ -124,4 +124,4 @@ def test_brotli_dynamic_expire(app):
             '/',
             headers=[('accept-encoding', 'gzip, br')])
 
-    assert resp.headers.get('x-brotli-cache') != 'HIT'
+    assert resp.headers.get('brotli-cache') != 'HIT'


### PR DESCRIPTION
removed `x-` prefix from custom headers, as per [section 8.3.1 of RFC7231](https://httpwg.org/specs/rfc7231.html#considerations.for.new.header.fields)