### PR TITLE
fix: posts not getting refreshed

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,7 @@
 
 * fix: picture tags having an extra comma
 * fix: outdated joke in about page
+* fix: posts' status not getting refreshed (ie whether or not they were faved, or deleted externally)
 * internals: removed `x-` prefix from custom headers, as per [section 8.3.1 of RFC7231](https://httpwg.org/specs/rfc7231.html#considerations.for.new.header.fields)
 
 ## v1.4.1 (security update)

--- a/libforget/twitter.py
+++ b/libforget/twitter.py
@@ -193,6 +193,7 @@ def refresh_posts(posts):
             db.session.delete(post)
         else:
             post = db.session.merge(post_from_api_tweet_object(tweet))
+            post.touch()
             refreshed_posts.append(post)
 
     return refreshed_posts

--- a/tasks.py
+++ b/tasks.py
@@ -231,6 +231,8 @@ def refresh_posts(posts):
 def refresh_account(account_id):
     account = Account.query.get(account_id)
 
+    print("Refreshing account {}".format(account))
+
     try:
         limit = 100
         if account.service == 'mastodon':


### PR DESCRIPTION
turns out i was not touching updated_at, so i'd always be refreshing
the same posts unless one of them actually changed

this is embarassing, there are posts in the DB that haven't been
refreshed since 2017