### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,7 +41,7 @@ pip or any python tools included in dependencies (honcho, flask...)
 
 ```
 $ pip install -r requirements.txt
-$ npm ci
+$ npm install
 ```
 
 Wow!! Exciting


### PR DESCRIPTION
npm ci only exists in recent-ish versions of npm. replaced with npm install