### PR TITLE
refresh_account: increment backoff if something crashes

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -316,6 +316,11 @@ def refresh_account(account_id):
         make_dormant(account)
         if sentry:
             sentry.captureException()
+    except Exception as e:
+        db.session.rollback()
+        account.backoff()
+        db.session.commit()
+        raise e
     finally:
         db.session.commit()
 


### PR DESCRIPTION
this is kind of a hotfix for the thing with pleroma returning bad error
messages crashing mastodon.py. but it's good practice anyway