### PR TITLE
fix newer twitter accounts not fetching new posts after the initial fetch

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+## next
+
+* fix: newer twitter accounts not fetching new posts past the initial historical fetch
+
 ## v1.6.1
 
 Released 2019-07-23

--- a/tasks.py
+++ b/tasks.py
@@ -157,7 +157,11 @@ def fetch_acc(id_):
             # ???
             raise TemporaryError("Fetching posts went horribly wrong")
 
-        if len(posts) == 0:
+        if (
+            len([post for post in posts if post.remote_id not in (max_id, since_id)])
+            == 0
+        ):
+            # if there are no posts other than the edges
             # we either finished the historic fetch
             # or we finished the current batch
             account.fetch_history_complete = True


### PR DESCRIPTION
twitter returns the post on the max_id boundary, which mastodon does not
do. the code that decides to move from historical fetch to a new batch
assumes that no posts will be returned at all when we're done, but in
twitter's case that will never happen, or not until the oldest post is
deleted. this change updates that code to ignore any posts returned that
match either max_id or since_id