### PR TITLE
ensure fetch_acc is rescheduled properly when doing historic fetch

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -180,7 +180,8 @@ def fetch_acc(id_):
 
             if not account.fetch_history_complete:
                 # reschedule immediately if we're still doing the historic fetch
-                fetch_acc.apply_async((id_,))
+                print("{} is not done fetching history, resheduling.".format(account))
+                fetch_acc.apply_async((id_,), countdown=1)
 
 
     except TemporaryError:


### PR DESCRIPTION
the unique decorator on the task means we can't reschedule it for right now but we must wait for the current one to end. this commit introduces a 1 second delay before the task is ran again, which should be enough