### PR TITLE
remove yarn from readme requirements

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,7 +18,7 @@ Forget is a post deleting service for Twitter and Mastodon. It lives at
 * Postgresql
 * Redis
 * Python 3.6+
-* Yarn or NPM
+* NPM
 
 
 ### Set up venv


### PR DESCRIPTION
yarn probably still works, but i don't use it and don't follow its
development so i can't say i support its use