### PR TITLE
remove method to upgrade known instances from cookie to localstorage

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+## vNEXT
+
+* removed: migration path for known instances list from cookie to localstorage
+  <https://github.com/codl/forget/pull/545>
+
 ## v2.1.0
 
 Released 2022-03-04

--- a/assets/instance_buttons.js
+++ b/assets/instance_buttons.js
@@ -20,34 +20,12 @@ import {SLOTS, normalize_known, known_load, known_save} from './known_instances.
     const misskey_top_instances =
         Function('return JSON.parse(`' + document.querySelector('#misskey_top_instances').innerHTML + '`);')();
 
-    async function get_known(){
+    async function replace_buttons(){
         let known = known_load();
-        if(!known){
-            let resp = await fetch('/api/known_instances');
-            if(resp.ok && resp.headers.get('content-type') == 'application/json'){
-                known = await resp.json();
-            }
-            else {
-                known = {
-                    mastodon:[{
-                        "instance": "mastodon.social",
-                        "hits": 0
-                    }],
-                    misskey:[{
-                        "instance": "misskey.io",
-                        "hits": 0
-                    }],
-                };
-            }
-            known_save(known)
-            fetch('/api/known_instances', {method: 'DELETE'})
-        }
 
-        return known;
-    }
+        known = normalize_known(known);
+        known_save(known);
 
-    function replace_buttons(top_instances, known_instances, container,
-            template, template_another_instance){
         let filtered_top_instances = []
         for(let instance of top_instances){
             let found = false;

--- a/assets/known_instances.js
+++ b/assets/known_instances.js
@@ -24,13 +24,21 @@ export function known_save(known){
 }
 
 export function known_load(){
+    const default_ = {
+        mastodon:[{ "instance": "mastodon.social", "hits": 0 }],
+        misskey:[{ "instance": "misskey.io", "hits": 0 }],
+    };
+    // this makes mastodon.social and misskey.io show up on respective first
+    // buttons by default even if they are not the most popular instance
+    // according to the server
+
     let known = localStorage.getItem(STORAGE_KEY);
     if(known){
         known = JSON.parse(known);
     } else {
         known = load_and_migrate_old();
     }
-    return known;
+    return known || default_;
 }
 
 export function normalize_known(known){

--- a/routes/api.py
+++ b/routes/api.py
@@ -67,22 +67,3 @@ def users_badge():
     return redirect(
             "https://img.shields.io/badge/active%20users-{}-blue.svg"
             .format(count))
-
-
-@app.route('/api/known_instances', methods=('GET', 'DELETE'))
-def known_instances():
-    if request.method == 'GET':
-        known = request.cookies.get('forget_known_instances', '')
-        if not known:
-            return Response('[]', 404, mimetype='application/json')
-
-        # pad to avoid oracle attacks
-        for _ in range(random.randint(0, 1000)):
-                known += random.choice((' ', '\t', '\n'))
-
-        return Response(known, mimetype='application/json')
-
-    elif request.method == 'DELETE':
-        resp = Response('', 204)
-        resp.set_cookie('forget_known_instances', '', max_age=0)
-        return resp


### PR DESCRIPTION
it's been over three years since the old forget_known_instances cookie is no longer being set, any cookie that hasn't been upgraded to localstorage by now has surely expired