### PR TITLE
fix exception when no posts are in database

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -428,7 +428,7 @@ def refresh_account_with_oldest_post():
         AND NOT accounts.dormant
         ORDER BY posts.updated_at ASC
         LIMIT 1;
-    """).columns(Post.id, Post.author_id)).one()
+    """).columns(Post.id, Post.author_id)).one_or_none()
     if post:
         aid = post.author_id
         refresh_account(aid)


### PR DESCRIPTION
Instead of using `Query.one` use `Query.one_or_none`. The check after setting the variable suggests this was the intended behaviour instead of throwing errors if there are no posts in the database.