### PR TITLE
fix: settings for misskey

### DIFF
--- a/libforget/misskey.py
+++ b/libforget/misskey.py
@@ -31,7 +31,7 @@ def get_or_create_app(instance_url, callback, website, session):
         r = session.post('{}://{}/api/app/create'.format(app.protocol, app.instance), json = {
             'name': 'forget',
             'description': website,
-            'permission': ['write:notes'],
+            'permission': ['write:notes', 'read:reactions'],
             'callbackUrl': callback
         })
         r.raise_for_status()

--- a/libforget/misskey.py
+++ b/libforget/misskey.py
@@ -31,7 +31,7 @@ def get_or_create_app(instance_url, callback, website, session):
         r = session.post('{}://{}/api/app/create'.format(app.protocol, app.instance), json = {
             'name': 'forget',
             'description': website,
-            'permission': ['read:favorites', 'write:notes'],
+            'permission': ['write:notes'],
             'callbackUrl': callback
         })
         r.raise_for_status()

--- a/templates/logged_in.html
+++ b/templates/logged_in.html
@@ -105,7 +105,7 @@
         <label for=policy_keep_media_none>neither</label>
     </span>
 </p>
-{% if g.viewer.account.service == 'mastodon' %}
+{% if g.viewer.account.service == 'mastodon' || g.viewer.account.service == 'misskey' %}
 <p>Keep direct messages:
     <span class="radiostrip">
         <span class="choice">

--- a/templates/logged_in.html
+++ b/templates/logged_in.html
@@ -70,6 +70,26 @@
     <input type=number name=policy_keep_latest min=0 step=1 style='max-width:8ch' value={{g.viewer.account.policy_keep_latest}}>
     most recent posts will be considered for deletion
 </p>
+{% if g.viewer.account.service == 'misskey' %}
+<p>…unless you
+    <span class="radiostrip">
+        <span class="choice">
+        <input type=radio name=policy_keep_favourites value=keeponly id=policy_keep_favourites_keeponly {{ "checked" if g.viewer.account.policy_keep_favourites == 'keeponly' }}>
+        <label for=policy_keep_favourites_keeponly>reacted to them</label>
+        </span>
+
+        <span class="choice">
+        <input type=radio name=policy_keep_favourites value=deleteonly id=policy_keep_favourites_deleteonly {{ "checked" if g.viewer.account.policy_keep_favourites == 'deleteonly' }}>
+        <label for=policy_keep_favourites_deleteonly>have not reacted to them</label>
+        </span>
+
+        <span class="choice">
+        <input type=radio name=policy_keep_favourites value=none id=policy_keep_favourites_none {{ "checked" if g.viewer.account.policy_keep_favourites == 'none' }}>
+        <label for=policy_keep_favourites_none>neither</label>
+        </span>
+    </span>
+</p>
+{%- else %}
 <p>…unless you
     <span class="radiostrip">
         <span class="choice">
@@ -88,6 +108,7 @@
         </span>
     </span>
 </p>
+{%- endif %}
 <p>…or unless they
     <span class="radiostrip">
         <span class="choice">


### PR DESCRIPTION
follow-up for #544

Got feedback that some of the setting descriptions are unclear or misleading in the context of Misskey. The setting for private post deletion is not displayed for Misskey.

Turns out I only remembered writing this from adjusting the privacy policy, which is thus still correct.